### PR TITLE
Add support for ScanTime

### DIFF
--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -224,6 +224,7 @@ void Keypad::setHoldTime(uint hold) {
     holdTime = hold;
 }
 
+// Wait this many ms after setting the output pin before checking the input pins
 void Keypad::setScanTime(uint scan) {
     scanTime = scan;
 }

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -92,7 +92,7 @@ void Keypad::scanKeys() {
 		pin_mode(columnPins[c],OUTPUT);
 		pin_write(columnPins[c], LOW);	// Begin column pulse output.
 		if(scanTime > 0) {
-			delay(scanTime);
+			delay(scanTime);  // DO NOT REMOVE! Prevents problems with the <Name & Model of keyboard>; https://github.com/Nullkraft/Keypad/pull/15
 		}
 		for (byte r=0; r<sizeKpd.rows; r++) {
 			bitWrite(bitMap[r], c, !pin_read(rowPins[r]));  // keypress is active low so invert to high.

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -92,7 +92,7 @@ void Keypad::scanKeys() {
 		pin_mode(columnPins[c],OUTPUT);
 		pin_write(columnPins[c], LOW);	// Begin column pulse output.
 		if(scanTime > 0) {
-			delay(scanTime);  // DO NOT REMOVE! Prevents problems with the <Name & Model of keyboard>; https://github.com/Nullkraft/Keypad/pull/15
+			delay(scanTime);  // DO NOT REMOVE! Prevents problems with the Joyjoz music mat hack; https://github.com/Nullkraft/Keypad/pull/15
 		}
 		for (byte r=0; r<sizeKpd.rows; r++) {
 			bitWrite(bitMap[r], c, !pin_read(rowPins[r]));  // keypress is active low so invert to high.

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -42,6 +42,7 @@ Keypad::Keypad(char *userKeymap, byte *row, byte *col, byte numRows, byte numCol
 
 	setDebounceTime(10);
 	setHoldTime(500);
+	setScanTime(0);
 	keypadEventListener = 0;
 
 	startTime = 0;
@@ -90,6 +91,9 @@ void Keypad::scanKeys() {
 	for (byte c=0; c<sizeKpd.columns; c++) {
 		pin_mode(columnPins[c],OUTPUT);
 		pin_write(columnPins[c], LOW);	// Begin column pulse output.
+		if(scanTime > 0) {
+			delay(scanTime);
+		}
 		for (byte r=0; r<sizeKpd.rows; r++) {
 			bitWrite(bitMap[r], c, !pin_read(rowPins[r]));  // keypress is active low so invert to high.
 		}
@@ -218,6 +222,10 @@ void Keypad::setDebounceTime(uint debounce) {
 
 void Keypad::setHoldTime(uint hold) {
     holdTime = hold;
+}
+
+void Keypad::setScanTime(uint scan) {
+    scanTime = scan;
 }
 
 void Keypad::addEventListener(void (*listener)(char)){

--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -102,6 +102,7 @@ public:
 	void begin(char *userKeymap);
 	void setDebounceTime(uint);
 	void setHoldTime(uint);
+	void setScanTime(uint);
 	void addEventListener(void (*listener)(char));
 	void addStatedEventListener(void (*listener)(char, KeyState));
 	int findInList(char keyChar);
@@ -116,6 +117,7 @@ private:
 	KeypadSize sizeKpd;
 	uint debounceTime;
 	uint holdTime;
+	uint scanTime;
 	unsigned long holdTimer;
 	bool single_key;
 


### PR DESCRIPTION
In my setup it takes up to 4ms after the output is set to low, for the input to also reach low, so I added a scanTime option to account for that.